### PR TITLE
Fix wrong markdown link to Contributor Covenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A website for learning ASL terms
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/lovehandle/asl-terms. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/lovehandle/asl-terms. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 
 ## License


### PR DESCRIPTION
This Readme.md was generated by a gem which introduced a malformed external link in the readme
